### PR TITLE
xtensa: disable reentrant syscall provision

### DIFF
--- a/newlib/configure.host
+++ b/newlib/configure.host
@@ -381,7 +381,6 @@ case "${host_cpu}" in
 	libm_machine_dir=xtensa
 	machine_dir=xtensa
 	newlib_cflags="${newlib_cflags} -mlongcalls"
-	newlib_cflags="${newlib_cflags} -DREENTRANT_SYSCALLS_PROVIDED"
         ;;
   z8k)
 	machine_dir=z8k


### PR DESCRIPTION
Current xtensa configuration considers that reentrant syscalls
are provided by the toolchain. Then, enabling newlib support
fails when using, for instance, _gettimeofday_r call provided
by zephyr's newlib and possibly in another reentrant calls.

Example:
newlib-cygwin/blob/zephyr-newlib-3.3.0/newlib/libc/reent/gettimeofdayr.c

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>