### PR TITLE
xtensa: Use default malloc alignment of 8

### DIFF
--- a/newlib/libc/include/sys/config.h
+++ b/newlib/libc/include/sys/config.h
@@ -195,7 +195,6 @@
 
 #ifdef __XTENSA__
 #include <xtensa/config/core-isa.h>
-#define MALLOC_ALIGNMENT ((XCHAL_DATA_WIDTH) < 16 ? 16 : (XCHAL_DATA_WIDTH))
 #endif
 
 /* This block should be kept in sync with GCC's limits.h.  The point


### PR DESCRIPTION
The current malloc implementation has a bug in which the first malloc
call may fail if MALLOC_ALIGNMENT is 16 and the requested block size is
such that malloc invokes sbrk with the heap expansion size that causes
the resulting heap address to fall on a page boundary.

sys/config.h was defining the minimum MALLOC_ALIGNMENT for the Xtensa
architecture as 16, and this caused the first malloc call to fail on
the Xtensa platforms in some rare cases that satisfy the conditions
described above (see zephyrproject-rtos/zephyr#38258).

Since the Xtensa architecture in itself does not require the malloc
alignment of 16, remove MALLOC_ALIGNMENT definition and use the default
alignment of 8 for all Xtensa platforms.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>