### PR TITLE
newlib: libc: create a generic machine/_threads.h

### DIFF
--- a/newlib/libc/include/machine/_threads.h
+++ b/newlib/libc/include/machine/_threads.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024, Friedt Professional Engineering Services, Inc
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _MACHINE__THREADS_H_
+#define _MACHINE__THREADS_H_
+
+#define ONCE_FLAG_INIT {0}
+#define TSS_DTOR_ITERATIONS 4
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef long cnd_t;
+typedef long mtx_t;
+typedef long thrd_t;
+typedef long tss_t;
+typedef struct {
+	char flag;
+} once_flag;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _MACHINE__THREADS_H_ */


### PR DESCRIPTION
The machine/_threads.h header defines specific types for C11 threads such as cnt_t, mtx_t, thrd_t, tss_t, and once_flag. However, the only definitions that currently exist in newlib are for rtems.

Create a relatively generic version of this such that most types can be represented as either integral values or pointers.

Machines or systems that require further specialization may do something similar to what was done for rtems.